### PR TITLE
Using jest-expect-message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kapeta/codegen",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kapeta/codegen",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "license": "MIT",
       "dependencies": {
         "checksum": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kapeta/codegen",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Kapeta code generator module",
   "main": "index.js",
   "repository": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,13 +2,10 @@ const CodeWriter = require('./CodeWriter');
 const Path = require("path");
 const FS = require("fs");
 
-let expect = () => {
-    throw new Error('jest tests must be run using jest');
-};
 try {
-    //jest globals throws when imported outside of jest tests
-    const globals = require("@jest/globals");
-    expect = globals.expect;
+    // override expect to add a message
+    const expectMessage = require("jest-expect-message");
+    expect = expectMessage.global.expect;
 } catch (e) {}
 
 function toUnixPermissions(statsMode) {
@@ -59,8 +56,7 @@ async function testCodeGenFor(target, generator, basedir) {
         const expected = FS.readFileSync(fullPath).toString();
         const stat = FS.statSync(fullPath);
         expect(toUnixPermissions(stat.mode)).toBe(result.permissions);
-        expect(expected).toBe(result.content);
-
+        expect(expected, `error in ${fullPath}`).toBe(result.content);
         const ix = allFiles.indexOf(fullPath);
         expect(allFiles).toContain(fullPath);
         if (ix > -1) {


### PR DESCRIPTION
This way we can write out what file is actually failing,
this is sort of nice when each deployment test contains multiple files