### PR TITLE
fix: attempt merge w/ existing files in fresh repo [CORE-2084]

### DIFF
--- a/src/CodeWriter.test.ts
+++ b/src/CodeWriter.test.ts
@@ -16,6 +16,7 @@ import { GeneratedFile, GeneratedResult, SourceFile, TargetMethods } from './typ
 import Path from 'node:path';
 import YAML from 'yaml';
 import checksum from 'checksum';
+import { Stats } from 'fs';
 
 const BASEDIR = '$tmp';
 
@@ -77,6 +78,11 @@ class TestFileSystemHandler implements FileSystemHandler {
         this.readDir(filename).forEach((path) => {
             delete this.files[path];
         });
+    }
+    stat(filename: string) {
+        return {
+            mode: 33188,
+        } as Stats;
     }
 }
 

--- a/src/CodeWriter.ts
+++ b/src/CodeWriter.ts
@@ -145,6 +145,7 @@ export class CodeWriter {
                                 };
                             }
                             const existingContent = this.fs.read(destinationFile);
+                            // Convert file permissions from octal number to base10 string and remove 100 prefix
                             const existingPermissions = this.fs.stat(destinationFile).mode.toString(8).slice(-3);
                             const sourceFile: SourceFile = {
                                 filename: newFile.filename,


### PR DESCRIPTION
Enables merge behavior for files in repo that is not yet in kapeta.
Previously we would only use merge for files that have metadata in kapeta/merged already.
